### PR TITLE
Guard tool-bar/scroll-bar/tooltip-mode calls with fboundp

### DIFF
--- a/lisp/setup-ui.el
+++ b/lisp/setup-ui.el
@@ -7,9 +7,9 @@
 
 ;; Turn off the menu, tool bars and the scroll bar
 (menu-bar-mode 0)
-(tool-bar-mode 0)
-(scroll-bar-mode 0)
-(tooltip-mode 1)
+(when (fboundp 'tool-bar-mode) (tool-bar-mode 0))
+(when (fboundp 'scroll-bar-mode) (scroll-bar-mode 0))
+(when (fboundp 'tooltip-mode) (tooltip-mode 1))
 ;; native linux tooltips are all right
 (when IS-LINUX (setq x-gtk-use-system-tooltips nil))
 ;; Turn on image viewing


### PR DESCRIPTION
## Problème

Sur les builds d'Emacs compilés sans support GUI (`--without-x --without-ns`), `scroll-bar-mode` n'est pas défini, ce qui fait échouer `init.el` au démarrage avec :

```
Symbol's function definition is void: scroll-bar-mode
```

Découvert en testant le bootstrap complet d'Elpaca dans un environnement isolé.

## Correctif

Dans `lisp/setup-ui.el`, protège les appels à `tool-bar-mode`, `scroll-bar-mode` et `tooltip-mode` avec `fboundp`, sur le même modèle que le garde déjà existant pour `horizontal-scroll-bar-mode` dans `early-init.el`.

## Test

- Bootstrap complet d'Elpaca dans un `HOME` isolé (`emacs --init-directory=... --fg-daemon`) : tous les fichiers `lisp/*.el` se chargent sans erreur fatale après le correctif.